### PR TITLE
Fix `IndexError` when an input text ends with `No.`.

### DIFF
--- a/bunkai/algorithm/bunkai_sbd/annotator/number_exception_annotator.py
+++ b/bunkai/algorithm/bunkai_sbd/annotator/number_exception_annotator.py
@@ -23,7 +23,7 @@ class NumberExceptionAnnotator(AnnotationFilter):
             return False
 
         if RE_NUMBER_WORD.match(original_text[start_index - 2:start_index]) and \
-                re.match(r'\d', original_text[end_index]):
+                end_index < len(original_text) and re.match(r'\d', original_text[end_index]):
             return True
         return False
 


### PR DESCRIPTION
I got an IndexError when an input text ends with only numero sign (number is not included), such as `No.`.

```python
>>> from bunkai import Bunkai

>>> bunkai = Bunkai()
>>> for sentence in bunkai("おすすめ度No."):
>>>     print(sentence)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/to/bunkai/bunkai/algorithm/bunkai_sbd/bunkai_sbd.py", line 89, in __call__
    annotations = self.eos(text)
  File "/path/to/bunkai/bunkai/algorithm/bunkai_sbd/bunkai_sbd.py", line 79, in eos
    rule_obj.annotate(text, annotations)
  File "/path/to/bunkai/bunkai/algorithm/bunkai_sbd/annotator/number_exception_annotator.py", line 34, in annotate
    if self.is_exception_no(original_text, __s.start_index, __s.end_index):
  File "/path/to/bunkai/bunkai/algorithm/bunkai_sbd/annotator/number_exception_annotator.py", line 26, in is_exception_no
    re.match(r'\d', original_text[end_index]):
IndexError: string index out of range
```

I think this error is caused by determining if the next character after the period is number if `No.` is present in the input text, whether the next character is present or not.
To avoid this error, I have added a validation check to determine if `end_index` is appropriate.