### PR TITLE
Changed packages only used for --model options to extras_require ([lb])

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ If you want to disambiguate sentence boundaries for line breaks, please add a ``
 
 To use ``--model`` option, it is need to install with extras:
     ``--model``オプションを利用するためにはextraパッケージをインストールする必要があります．
+
 ```console
 $ pip install -U bunkai[lb]
 ```

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ $ echo -e '宿を予約しました♪!まだ2ヶ月も先だけど。早すぎ�
 If you want to disambiguate sentence boundaries for line breaks, please add a ``--model`` option with the path to the model.  
     改行記号に対しても文境界判定を行いたい場合は，``--model``オプションを与える必要があります．
 
+To use ``--model`` option, it is need to install with extras:
+    ``--model``オプションを利用するためにはextraパッケージをインストールする必要があります．
+```console
+$ pip install -U bunkai[lb]
+```
+
 First time, please setup a model. It will take some time.  
     はじめにモデルをセットアップする必要があります．セットアップには少々時間がかかります．
 

--- a/bunkai/algorithm/bunkai_sbd/annotator/__init__.py
+++ b/bunkai/algorithm/bunkai_sbd/annotator/__init__.py
@@ -5,7 +5,7 @@ from bunkai.algorithm.bunkai_sbd.annotator.emoji_annotator import EmojiAnnotator
 from bunkai.algorithm.bunkai_sbd.annotator.emotion_expression_annotator import EmotionExpressionAnnotator
 from bunkai.algorithm.bunkai_sbd.annotator.facemark_detector import FaceMarkDetector
 from bunkai.algorithm.bunkai_sbd.annotator.indirect_quote_exception_annotator import IndirectQuoteExceptionAnnotator
-from bunkai.algorithm.bunkai_sbd.annotator.linebreak_annotator import LinebreakAnnotator
+from bunkai.algorithm.bunkai_sbd.annotator.linebreak_annotator_compat import LinebreakAnnotator
 from bunkai.algorithm.bunkai_sbd.annotator.linebreak_force_annotator import LinebreakForceAnnotator
 from bunkai.algorithm.bunkai_sbd.annotator.morph_annotator import MorphAnnotatorJanome
 from bunkai.algorithm.bunkai_sbd.annotator.number_exception_annotator import NumberExceptionAnnotator

--- a/bunkai/algorithm/bunkai_sbd/annotator/indirect_quote_exception_annotator.py
+++ b/bunkai/algorithm/bunkai_sbd/annotator/indirect_quote_exception_annotator.py
@@ -7,7 +7,7 @@ from bunkai.algorithm.bunkai_sbd.annotator.constant import LAYER_NAME_FIRST
 from bunkai.algorithm.bunkai_sbd.annotator.emoji_annotator import EmojiAnnotator
 from bunkai.algorithm.bunkai_sbd.annotator.emotion_expression_annotator import EmotionExpressionAnnotator
 from bunkai.algorithm.bunkai_sbd.annotator.facemark_detector import FaceMarkDetector
-from bunkai.algorithm.bunkai_sbd.annotator.linebreak_annotator import LinebreakAnnotator
+from bunkai.algorithm.bunkai_sbd.annotator.linebreak_annotator_compat import LinebreakAnnotator
 from bunkai.algorithm.bunkai_sbd.annotator.morph_annotator import MorphAnnotatorJanome
 from bunkai.base.annotation import Annotations, SpanAnnotation, TokenResult
 from bunkai.base.annotator import AnnotationFilter

--- a/bunkai/algorithm/bunkai_sbd/annotator/linebreak_annotator_compat.py
+++ b/bunkai/algorithm/bunkai_sbd/annotator/linebreak_annotator_compat.py
@@ -1,0 +1,15 @@
+try:
+    import numpy
+    import transformers
+    import torch
+except ImportError:
+    install_with_lb = False
+else:
+    install_with_lb = True
+
+if install_with_lb:
+    from bunkai.algorithm.bunkai_sbd.annotator.linebreak_annotator import LinebreakAnnotator
+else:
+    # void class for compat
+    class LinebreakAnnotator:
+        pass

--- a/bunkai/algorithm/bunkai_sbd/annotator/linebreak_annotator_compat.py
+++ b/bunkai/algorithm/bunkai_sbd/annotator/linebreak_annotator_compat.py
@@ -1,7 +1,8 @@
+#!/usr/bin/env python3
 try:
-    import numpy
-    import transformers
-    import torch
+    import numpy  # noqa: F401
+    import torch  # noqa: F401
+    import transformers  # noqa: F401
 except ImportError:
     install_with_lb = False
 else:
@@ -12,4 +13,5 @@ if install_with_lb:
 else:
     # void class for compat
     class LinebreakAnnotator:
-        pass
+        def __init__(self, *, path_model):
+            raise Exception("You need to install bunkai with pip install -U bunkai[lb]")

--- a/bunkai/cli.py
+++ b/bunkai/cli.py
@@ -69,9 +69,9 @@ def get_opts() -> argparse.Namespace:
 
 def is_install_with_lb() -> bool:
     try:
-        import numpy
-        import torch
-        import transformers
+        import numpy  # noqa: F401
+        import torch  # noqa: F401
+        import transformers  # noqa: F401
     except ImportError:
         return False
     else:

--- a/mks/lint.mk
+++ b/mks/lint.mk
@@ -4,14 +4,15 @@ TERMS_CHECK_CMD:=grep -e split -e divide
 TERMS_CHECK_CONTENT_OPTION:=-e 文分割 -e 'coding: utf'
 
 POETRY_NO_ROOT:= --no-root
+POETRY_LB:= -E lb
 
 dev_setup:
-	poetry install $(POETRY_NO_ROOT) $(POETRY_OPTION)
+	poetry install $(POETRY_NO_ROOT) $(POETRY_LB) $(POETRY_OPTION)
 
 setup: setup_python setup_npm
 
 setup_python:
-	poetry install $(POETRY_OPTION)
+	poetry install $(POETRY_LB) $(POETRY_OPTION)
 
 setup_npm:
 	npm install

--- a/poetry.lock
+++ b/poetry.lock
@@ -109,7 +109,7 @@ name = "filelock"
 version = "3.6.0"
 description = "A platform independent file lock."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.extras]
@@ -134,7 +134,7 @@ name = "huggingface-hub"
 version = "0.5.1"
 description = "Client library to download and publish models on the huggingface.co hub"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7.0"
 
 [package.dependencies]
@@ -349,7 +349,7 @@ name = "regex"
 version = "2022.3.15"
 description = "Alternative regular expression module, to replace re."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [[package]]
@@ -375,7 +375,7 @@ name = "sacremoses"
 version = "0.0.49"
 description = "SacreMoses"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -433,7 +433,7 @@ name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
@@ -468,7 +468,7 @@ name = "tokenizers"
 version = "0.12.0"
 description = "Fast and Customizable Tokenizers"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.extras]
@@ -496,7 +496,7 @@ name = "torch"
 version = "1.11.0"
 description = "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7.0"
 
 [package.dependencies]
@@ -524,7 +524,7 @@ name = "transformers"
 version = "4.18.0"
 description = "State-of-the-art Natural Language Processing for TensorFlow 2.0 and PyTorch"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6.0"
 
 [package.dependencies]
@@ -624,10 +624,13 @@ python-versions = ">=3.5"
 pathspec = ">=0.5.3"
 pyyaml = "*"
 
+[extras]
+lb = ["torch", "transformers", "numpy"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<4.0"
-content-hash = "04626e155ab423b33c1875ad7b09098e32d202c9b41b3df583d01545e27431c2"
+content-hash = "58515c3fa8b8b7ef47cb620a9d6eb006743e6b330578467ef9c6e05def6b2eab"
 
 [metadata.files]
 black = [
@@ -782,6 +785,7 @@ numpy = [
     {file = "numpy-1.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8251ed96f38b47b4295b1ae51631de7ffa8260b5b087808ef09a39a9d66c97ab"},
     {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48a3aecd3b997bf452a2dedb11f4e79bc5bfd21a1d4cc760e703c31d57c84b3e"},
     {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3bae1a2ed00e90b3ba5f7bd0a7c7999b55d609e0c54ceb2b076a25e345fa9f4"},
+    {file = "numpy-1.22.3-cp310-cp310-win32.whl", hash = "sha256:f950f8845b480cffe522913d35567e29dd381b0dc7e4ce6a4a9f9156417d2430"},
     {file = "numpy-1.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:08d9b008d0156c70dc392bb3ab3abb6e7a711383c3247b410b39962263576cd4"},
     {file = "numpy-1.22.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:201b4d0552831f7250a08d3b38de0d989d6f6e4658b709a02a73c524ccc6ffce"},
     {file = "numpy-1.22.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f8c1f39caad2c896bc0018f699882b345b2a63708008be29b1f355ebf6f933fe"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,14 @@ janome = ">=0.4.1"
 seqeval = ">=1.2.2"
 spans = ">=1.1.0"
 tqdm = "*"
-numpy = ">=1.16.0"
-torch = ">=1.3.0"
-transformers = ">=4.3.2"
+numpy = {version = ">=1.16.0", optional = true}
+torch = {version = ">=1.3.0", optional = true}
+transformers = {version = ">=4.3.2", optional = true}
 more_itertools = ">=8.6.0"
 emoji = ">=1.2.0"
 emojis = ">=0.6.0"
 toml = ">=0.10.2"
+requests = "^2.27.1"
 
 [tool.poetry.dev-dependencies]
 coverage = ">=5.3"
@@ -34,6 +35,9 @@ yamllint = ">=1.25.0"
 mock = ">=4.0.2"
 pydocstyle = ">=5.1.1"
 black = ">=21.10b0"
+
+[tool.poetry.extras]
+lb = ["torch", "transformers", "numpy"]
 
 [build-system]
 requires = ["poetry"]


### PR DESCRIPTION
To simplify the dependency package, numpy, transformers, and torch, which are used only when the --model option is used, are changed to extras_require as [lb].